### PR TITLE
Add :context to track_and_identify

### DIFF
--- a/lib/analytics/patches.rb
+++ b/lib/analytics/patches.rb
@@ -1,8 +1,8 @@
 module AnalyticsRuby
-  def self.track_and_identify(event, properties, user)
-    identify(:user_id => user.id, :traits => user.identity_payload)
+  def self.track_and_identify(event, properties, user, context={})
+    identify(:user_id => user.id, :traits => user.identity_payload, :context => context)
     #Hubspot and others need an email address in the event...
     properties = {:email => user.email}.merge(properties)
-    track(:user_id => user.id, :event => event, :properties => properties)
+    track(:user_id => user.id, :event => event, :properties => properties, :context => context)
   end
 end

--- a/spec/analytics_spec.rb
+++ b/spec/analytics_spec.rb
@@ -120,19 +120,21 @@ describe "Analytics" do
             @identity_payload = payload
           end
         end
-        @user = User.new(1, {})
       end
 
+      let(:user) { User.new(1, {}) }
+
       it "without context" do
-        Analytics.ss.should_receive(:identify).with(:user_id => @user.id, :traits => {}, :context => {})
-        Analytics.ss.should_receive(:track).with(:event => "Something", :properties => {:foo => "bar", :email => "#{@user.id}@crowdflower.com"}, :user_id => @user.id, :context => {})
-        expect(Analytics.ss.track_and_identify("Something", {:foo => "bar"}, @user))
+        expect(Analytics.ss).to receive(:identify).with(:user_id => user.id, :traits => {}, :context => {})
+        expect(Analytics.ss).to receive(:track).with(:event => "Something", :properties => {:foo => "bar", :email => "#{user.id}@crowdflower.com"}, :user_id => user.id, :context => {})
+        Analytics.ss.track_and_identify("Something", {:foo => "bar"}, user)
+
       end
 
       it "with context" do
-        Analytics.ss.should_receive(:identify).with(:user_id => @user.id, :traits => {}, :context => { 'Marketo' => { marketoCookie: "somevalue" } })
-        Analytics.ss.should_receive(:track).with(:event => "Something", :properties => {:foo => "bar", :email => "#{@user.id}@crowdflower.com"}, :user_id => @user.id, :context => { 'Marketo' => { marketoCookie: "somevalue" } })
-        expect(Analytics.ss.track_and_identify("Something", {:foo => "bar"}, @user, { 'Marketo' => { marketoCookie: "somevalue" } }))
+        expect(Analytics.ss).to receive(:identify).with(:user_id => user.id, :traits => {}, :context => { 'Marketo' => { marketoCookie: "somevalue" } })
+        expect(Analytics.ss).to receive(:track).with(:event => "Something", :properties => {:foo => "bar", :email => "#{user.id}@crowdflower.com"}, :user_id => user.id, :context => { 'Marketo' => { marketoCookie: "somevalue" } })
+        Analytics.ss.track_and_identify("Something", {:foo => "bar"}, user, { 'Marketo' => { marketoCookie: "somevalue" } })
       end
     end
 


### PR DESCRIPTION
@workshur @marat-ad @onewland 

As per https://segment.com/docs/integrations/marketo, I'm adding a possibility to specify `context` as part of analytics payload. With that we can send Marketo cookie in `context` and add tracking of backend events.

Related: https://github.com/CrowdFlower/CrowdFlower/pull/2277,
https://github.com/CrowdFlower/CrowdFlower/pull/2278

https://crowdflower.atlassian.net/browse/UX-3439